### PR TITLE
Added speedtest

### DIFF
--- a/nethserver-diagtools.spec
+++ b/nethserver-diagtools.spec
@@ -1,6 +1,6 @@
 Summary: NethServer diagnostic tools
 %define name nethserver-diagtools
-%define version 0.0.8
+%define version 0.0.9
 %define release 1
 Name: %{name}
 Version: %{version}
@@ -11,6 +11,7 @@ BuildArch: noarch
 URL: http://dev.nethserver.org/projects/nethforge/wiki/%{name}
 BuildRequires: nethserver-devtools
 Requires: arp-scan
+Requires: speedtest-cli
 #AutoReq: no
 
 %description
@@ -42,6 +43,9 @@ rm -rf $RPM_BUILD_ROOT
 %dir %{_nseventsdir}/%{name}-update
 
 %changelog
+* Wed Oct 04 2017 Stephane de Labrusse <stephdl@de-labrusse.fr> - 0.0.9-1-ns7
+- Added speedtest-cli
+
 * Thu Mar 02 2017 Stephane de Labrusse <stephdl@de-labrusse.fr> - 0.0.8-1-ns7
 - Added copyright and GPLV3 License.
 

--- a/root/etc/e-smith/templates/etc/sudoers/20diagtools
+++ b/root/etc/e-smith/templates/etc/sudoers/20diagtools
@@ -5,6 +5,7 @@
     push @cmnd_alias_httpd_admin, qw(
     /usr/bin/traceroute
     /usr/sbin/arp-scan
+    /usr/bin/speedtest-cli
     );
     '';
 }

--- a/root/usr/share/nethesis/NethServer/Language/en/NethServer_Module_DiagTools.php
+++ b/root/usr/share/nethesis/NethServer/Language/en/NethServer_Module_DiagTools.php
@@ -26,3 +26,7 @@ $L['ScanHosts_Title'] = 'Scan';
 $L['DiagToolsScanHost_header'] = 'Scan your local networks';
 $L['nic_label'] = 'Network Interfaces';
 $L['ScanHost_label'] = 'Scan';
+$L['DiagToolsSpeedTest_header'] = 'Test your Internet bandwidth';
+$L['server_label'] = 'Server ID (see speedtest servers)';
+$L['SpeedTest_Title'] = 'Speedtest';
+$L['SpeedTest_label'] = 'Speedtest';

--- a/root/usr/share/nethesis/NethServer/Module/DiagTools/SpeedTest.php
+++ b/root/usr/share/nethesis/NethServer/Module/DiagTools/SpeedTest.php
@@ -1,0 +1,103 @@
+<?php
+/*
+ * Copyright (C) 2017 Stephane de Labrusse <stephdl@de-labrusse.fr>
+ *
+ * This script is part of NethServer.
+ *
+ * NethServer is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License,
+ * or any later version.
+ *
+ * NethServer is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with NethServer.  If not, see COPYING.
+ */
+
+namespace NethServer\Module\DiagTools;
+
+use Nethgui\System\PlatformInterface as Validate;
+
+/**
+ * Implement gui module for diagnostic tools
+ */
+
+class  SpeedTest extends \Nethgui\Controller\AbstractController
+{
+
+    private $report;
+
+    private function getReport()
+    {
+        $nic = $this->parameters['nic'];
+        $ip = $this->getPlatform()->getDatabase('networks')->getProp($nic, 'ipaddr');
+        $server = $this->parameters['server'];
+        if (! empty($server) && isset($nic)) {
+            return $this->getPlatform()->exec(sprintf('/usr/bin/sudo /usr/bin/speedtest-cli --server='
+                .\escapeshellarg($server).' --source='.\escapeshellarg($ip). ' 2>&1'))->getOutput();
+        }
+        elseif (isset($nic) ) {
+            return $this->getPlatform()->exec(sprintf('/usr/bin/sudo /usr/bin/speedtest-cli --source='
+                .\escapeshellarg($ip). ' 2>&1'))->getOutput();
+        }
+    }
+
+    private function readNic()
+    {
+        static $interfaces;
+
+        if (isset($interfaces)) {
+            return $interfaces;
+        }
+
+        $nic = array();
+        foreach ($this->getPlatform()->getDatabase('networks')->getAll() as $key => $values) {
+            if (isset($values['role']) && $values['role'] == 'red' && isset($values['ipaddr'])) {
+                $nicRed[] = $key;
+                $redcount++;
+           }
+            elseif (isset($values['role']) && $values['role'] == 'green' && isset($values['ipaddr'])) {
+               $nicGreen[] = $key;
+           }
+        }
+        if ( $redcount >= '1') { $nic = $nicRed;}
+        elseif ( ! isset($redcount)) { $nic = $nicGreen;}
+
+        return $nic;
+    }
+
+    public function initialize()
+    {
+        $this->declareParameter('nic', Validate::ANYTHING);
+        $this->declareParameter('server', $this->createValidator()
+            ->orValidator($this->createValidator(Validate::POSITIVE_INTEGER), $this->createValidator(Validate::EMPTYSTRING)));
+        parent::initialize();
+    }
+
+    public function bind(\Nethgui\Controller\RequestInterface $request)
+    {
+        parent::bind($request);
+        $this->report = $this->getReport();
+    }
+
+    public function prepareView(\Nethgui\View\ViewInterface $view)
+    {
+        parent::prepareView($view);
+        if (!$this->report) {
+            $this->report = $this->getReport();
+        }
+        $view['report'] = $this->report;
+
+        if (!$this->templates) {
+            $this->templates = $this->readNic();
+        }
+        $view['nicDatasource'] = array_map(function($fmt) use ($view) {
+            return array($fmt, $view->translate($fmt));
+        }, $this->templates);
+    }
+}
+

--- a/root/usr/share/nethesis/NethServer/Template/DiagTools/SpeedTest.php
+++ b/root/usr/share/nethesis/NethServer/Template/DiagTools/SpeedTest.php
@@ -1,0 +1,22 @@
+<?php
+/* @var $view Nethgui\Renderer\Xhtml */
+echo $view->header()->setAttribute('template', $T('DiagToolsSpeedTest_header'));
+
+echo $view->selector('nic', $view::SELECTOR_DROPDOWN);
+echo $view->textInput('server')->setAttribute('placeholder', $T('LeaveBlankForAutomatic'));;
+
+echo $view->buttonList()
+    ->insert($view->button('SpeedTest', $view::BUTTON_SUBMIT));
+
+echo "<pre class='DiagTools_SpeedTest'>";
+echo $view->textLabel('report');
+echo "</pre>";
+
+
+$view->includeCss('
+    pre.DiagTools_SpeedTest {
+        border: 2px solid #aaa;
+        padding: 10px;
+        width: 850px;
+    }
+');


### PR DESCRIPTION
Following https://community.nethserver.org/t/nethserver-network-diag/5317/60, I added speedtest

Please can you review the code.

My worry is concerning the state of the epel rpm of speedtest-cli, now only in epel-testing, but I bet it is a short stage before to be released. I prefer to go to the rpm, rather than the pip option. It is better for upgrade.

Probably the speedtest-cli rpm could go to nethforge, what do you think ?