### PR TITLE
spec: add perl-LWP-Protocol-https dependency

### DIFF
--- a/nethserver-diagtools.spec
+++ b/nethserver-diagtools.spec
@@ -9,7 +9,7 @@ URL: %{url_prefix}/%{name}
 BuildRequires: nethserver-devtools
 Requires: arp-scan
 Requires: speedtest-cli
-#AutoReq: no
+Requires: perl-LWP-Protocol-https
 
 %description
 NethServer diagnostic tool


### PR DESCRIPTION
Servers of standards-oui.ieee.org now redirect traffic
from HTTP to HTTPS.

NethServer/dev#6642